### PR TITLE
add middleware to check for valid api key

### DIFF
--- a/src/api/middleware.js
+++ b/src/api/middleware.js
@@ -1,0 +1,12 @@
+const middleWare = {
+  checkAPIKey: (req, res, next) => {
+    if(req.query.key && req.query.key === process.env.WEATHER_FETCH_SERVICE_API_KEY) {
+      return next();
+    }
+    res.sendStatus(401);
+  }
+}
+
+
+
+module.exports = middleWare;

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -1,8 +1,9 @@
 const express = require('express'),
       db = require('../db/connection.js'),
+      middleWare = require('./middleware.js'),
       router = express.Router();
 
-router.get('/api/v1/weather-data/:zip_code', (req, res) => {
+router.get('/api/v1/weather-data/:zip_code', middleWare.checkAPIKey, (req, res) => {
   db.select('data')
     .from('weather_data')
     .where({ zip_code: req.params.zip_code })


### PR DESCRIPTION
This adds a check for a valid api key being sent to the `GET` route before responding with weather data. If a valid api key is not sent the server responds with 401 `Unauthorized`.