### PR TITLE
remove unnecessary db tbls

### DIFF
--- a/migrations/20191018142111_create_us_weather_data_tables.js
+++ b/migrations/20191018142111_create_us_weather_data_tables.js
@@ -6,34 +6,6 @@ exports.up = function(knex) {
       tbl.jsonb('data');
       tbl.timestamps(true, true);
     })
-    .createTable('us_eastern', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_central', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_mountain', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_arizona', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_pacific', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_alaska', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
-    .createTable('us_hawaii', tbl => {
-      tbl.inherits('weather_data');
-      tbl.unique('zip_code');
-    })
 };
 
 exports.down = function(knex) {


### PR DESCRIPTION
This removes all time zone db tables. The weather service's scope is re-focussed on only fetching/storing weather data and is not concerned with which time zone the weather data belongs. Time zone is a concern of the zip code service.